### PR TITLE
Love some unloved pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ src/volumes
 **/.DS_Store
 **/*.swp
 **/__pycache__
+build-and-run.sh

--- a/docs/template_fields.md
+++ b/docs/template_fields.md
@@ -10,7 +10,7 @@ To the public user view:
     "pfp":          access ID of the user's profile picture (string),
     "status":       user's status (string),
     "suspended":    whether or not user is suspended (0 or 1),
-    "posts":        list of user's posts, as pairs of post IDs and titles ([(int, string)]),
+    "posts":        list of user's posts, as a dictionary with post IDs and titles ({'pid': int, 'title': string}),
     "friends":      list of friends, as pairs of user IDs and usernames ([(int, string)]),
 }
 ```

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -8,13 +8,19 @@ hr {
 }
 
 .hbox {
-	display: inline-block;
+/* a box for displaying things spaced horizontally */
+    display: inline-block;
     position: fixed;
     vertical-align: baseline;
 }
 
+.vbox {
+/* a box for displaying things spaced vertically */
+
+}
+
 .group {
-    margin: 1%;
+    margin: 2%;
 }
 
 .thumbnail {
@@ -106,16 +112,24 @@ nav * {
 
 /* profile */
 
-#friends-list {
+.naked-list {
     list-style: none;
     margin: 0;
     padding: 0;
 }
 
-/* posts */
+/* post */
 
 #post-preview {
     border-style: solid;
     width: 50%;
+}
+
+/* comment */
+
+.comment {
+    margin: 0;
+    padding: 0;
+    list-style: none;
 }
 

--- a/src/templates/DEMO.html
+++ b/src/templates/DEMO.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+
+<div class="group">
+    <h1>{% block title %}tab-name-here{% endblock %}</h1>
+
+    {% block content %}
+
+    <p>Some content.</p>
+
+</div>
+{% endblock %}

--- a/src/templates/account.html
+++ b/src/templates/account.html
@@ -1,3 +1,12 @@
+{% extends 'base.html' %}
+
+<h1>{% block title %}{{ data['username'] }}{% endblock %}</h1>
+
+{% block content %}
+
 <h1>Welcome to your account page, {{ data['username'] }}!</h1>
 <p>Your status: "{{ data['status'] }}"</p>
 <p>Your email: {{ data['email'] }}</p>
+
+{% endblock %}
+

--- a/src/templates/error.html
+++ b/src/templates/error.html
@@ -1,3 +1,14 @@
-God dammit! Something went wrong!
+{% extends 'base.html' %}
 
-The error is called {{ data['error'] }}. That mean anything to you?
+<h1>{% block title %}tab-name-here{% endblock %}</h1>
+
+{% block content %}
+
+<div class="group">
+    <p>God dammit! Something went wrong!</p>
+
+    <p>The error is called {{ data['error'] }}. That mean anything to you?</p>
+
+</div>
+{% endblock %}
+

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,7 +1,13 @@
 {% extends 'base.html' %}
 
-<h1>home page</h1>
+<h1>{% block title %}home{% endblock %}</h1>
 
-<div id="feed-posts-box">
-    {# include 'post-preview.html' #}
+{% block content %}
+<div class="group">
+
+    <h1>Welcome to Agora!</h1>
+    <p>See my code on <a href="https://github.com/franklindyer/agora-app" target="_blank" rel="noopener noreferrer">GitHub</a>!</p>
+
 </div>
+{% endblock %}
+

--- a/src/templates/post-preview.html
+++ b/src/templates/post-preview.html
@@ -1,4 +1,4 @@
-<h1>{{ data['title'] }}</h1>
+<h1>{{ data['posts'] }}</h1>
 
 By <b>{{ data['username'] }}</b>
 

--- a/src/templates/post.html
+++ b/src/templates/post.html
@@ -1,16 +1,29 @@
-<h1>{{ data['title'] }}</h1>
+{% extends 'base.html' %}
 
-By <b>{{ data['username'] }}</b>
+<h1>{% block title %}{{ data['title'] }}{% endblock %}</h1>
 
-{{ data['content'] | safe }}
+{% block content %}
 
-<hr>
+<div class="group">
 
-Votes: {{ data['votes'] }}
+    <h1>{{ data['title'] }}</h1>
 
-<h2>Comments:</h2>
-<ul>
-{% for c in data['comments'] %}
-<li><a href="/user/{{ c['uid'] }}"><b>@{{ c['username'] }}</b></a>: &nbsp; {{ c['content'] }}</li>
-{% endfor %}
-</ul>
+    By <b>{{ data['username'] }}</b>
+
+    {{ data['content'] | safe }}
+
+    <hr>
+
+    Votes: {{ data['votes'] }}
+
+    <h2>Comments:</h2>
+    <ul>
+    {% for c in data['comments'] %}
+    <li class="comment"><a href="/user/{{ c['uid'] }}"><b>@{{ c['username'] }}</b></a>: &nbsp; {{ c['content'] }}</li>
+    {% endfor %}
+    </ul>
+
+</div>
+
+{% endblock %}
+

--- a/src/templates/profile.html
+++ b/src/templates/profile.html
@@ -5,7 +5,9 @@
 {% block content %}
 
 <div class="group">
-    <img class="profile-picture" src="{{ url_for('static', filename='img/default-pfp.png') }}" alt="the user's profile picture">
+    <img class="profile-picture" 
+         src="{{ url_for('static', filename='img/default-pfp.png') }}" 
+         alt="the user's profile picture">
     <div class="group hbox">
 	    <h2 id="profile-username" class="group-header">@{{ data['username'] }}</h2>
 	    <p>Status: "{{ data['status'] }}"</p>
@@ -14,13 +16,20 @@
 
 <div class="group">
     <h2 class="group-header">Friends: {{ data['friends']|length }}</h2>
-    <ul id="friends-list">
-    {% for (id, name) in data['friends'] %}
-        <li><a href="/user/{{ id }}">@{{ name }}</a></li>
+    <ul class="naked-list">
+    {% for (uid, name) in data['friends'] %}
+        <li><a href="/user/{{ uid }}">@{{ name }}</a></li>
     {% endfor %}
     </ul>
 </div>
 
-<div id="posts-box"></div>
+<div class="group">
+    <h2>Posts: {{ data['posts']|length }}</h2>
+    <ul class="naked-list">
+    {% for post in data['posts'] %}
+        <li><a href="/post/{{ post['pid'] }}">{{ post['title'] }}</a></li>
+    {% endfor %}
+    </ul>
+</div>
 
 {% endblock %}


### PR DESCRIPTION
I did a lot of small edits to most of the template files for different pages. Mostly, this was making sure they all extended the `base.html` template which provides tab titles and CSS.

I added one feature, which is a list of post titles on a user's profile. I am no longer using the `post-preview.html` template, but I've updated it and am keeping it around because I may decide to further modularize `profile.html`. 

I also added a template `DEMO.html` which can be used to create future templates that extend the base environment, to make initial template setup a little easier.