### PR TITLE
Database improvements

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -66,6 +66,7 @@ def agoraError(err):
 
 @app.before_request
 def agoraPreproc():
+    agoraDB.connect()
     g.data = {}
     g.sessionToken = request.cookies.get("session")
     try:

--- a/src/utilities/AgoraDatabaseManager.py
+++ b/src/utilities/AgoraDatabaseManager.py
@@ -1,4 +1,5 @@
-import sqlite3
+import os, sqlite3
+from multiprocessing.pool import ThreadPool
 
 def dict_factory(cursor, row):
     d = {}
@@ -9,31 +10,35 @@ def dict_factory(cursor, row):
 class AgoraDatabaseManager:
     def __init__(self, dbname):
         self.dbname = dbname
-        self.conn = sqlite3.connect(dbname)
-        self.conn.row_factory = dict_factory
+        self.connPool = ThreadPool(processes=1)
+        self.connect()
 
-    def cur(self):
-        # Making a new connection each time is only a temporary band-aid, not a long-term fix.
-        # It solves the problem of a single connection being unshareable between threads, and Flask being multithreaded.
-        # The ultimate solution will be to create a "job queue" as part of this class.
-        self.conn = sqlite3.connect(self.dbname)
+    def connect(self):
+        self.conn = sqlite3.connect(self.dbname, check_same_thread=False)
         self.conn.row_factory = dict_factory
-        return self.conn.cursor()
 
     def commit(self):
         self.conn.commit()
 
-    def query(self, query, args=(), one=False):
+    def cur(self):
+        return self.conn.cursor()
+
+    def pool_query(self, query, args=()):
         cur = self.cur().execute(query, args)
         res = [x for x in cur.fetchall()]
         cur.close()
         return (res if len(res) > 0 else None)
 
-    def execute(self, query, args=(), one=False):
+    def pool_execute(self, query, args=()):
         cur = self.cur().execute(query, args)
         cur.close()
         self.commit()
 
+    def query(self, query, args=()):
+        return self.connPool.apply(self.pool_query, (query, args,))
+
+    def execute(self, query, args=()):
+        return self.connPool.apply(self.pool_execute, (query, args,))
 
 
     def usernameExists(self, username):

--- a/src/utilities/AgoraDatabaseManager.py
+++ b/src/utilities/AgoraDatabaseManager.py
@@ -10,7 +10,8 @@ def dict_factory(cursor, row):
 class AgoraDatabaseManager:
     def __init__(self, dbname):
         self.dbname = dbname
-        self.connPool = ThreadPool(processes=1)
+        self.readPool = ThreadPool(processes=10)
+        self.writePool = ThreadPool(processes=1)
         self.connect()
 
     def connect(self):
@@ -35,10 +36,10 @@ class AgoraDatabaseManager:
         self.commit()
 
     def query(self, query, args=()):
-        return self.connPool.apply(self.pool_query, (query, args,))
+        return self.readPool.apply(self.pool_query, (query, args,))
 
     def execute(self, query, args=()):
-        return self.connPool.apply(self.pool_execute, (query, args,))
+        return self.writePool.apply(self.pool_execute, (query, args,))
 
 
     def usernameExists(self, username):


### PR DESCRIPTION
Fixes #3

Now all RO queries to the database pass through a threadpool with 10 members (we can increase or parametrize later as needed), and all RW queries pass through a single-thread pool for synchronization.