### PR TITLE
Search functionality added

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -206,4 +206,19 @@ def delete_image(imgid):
     agoraModel.deleteImage(sessionToken, imgid)
     return redirect('/account')
 
+@app.route('/search', methods=['POST'])
+def search():
+    data = request.form
+    results = []
+    querytype = ""
+    if "user" in data:
+        querytype = "user"
+        results = agoraModel.searchUsers(data["user"])
+    if "post" in data:
+        querytype = "post"
+        results = agoraModel.searchPosts(data["post"])
+    g.data["querytype"] = querytype
+    g.data["results"] = results
+    return render_template("results.html", data=g.data)
+
 app.run(host = "0.0.0.0", port = PORT)

--- a/src/templates/results.html
+++ b/src/templates/results.html
@@ -1,0 +1,23 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<div class="group">
+
+    <h1>Search results:</h1>
+    
+    <!-- TODO: replace this with a fancier image list, or even put this in another template  -->
+    <ul>
+    {% if data["querytype"] == "user" %}
+    {% for res in data['results'] %}
+        <li><a href="/user/{{ res['uid'] }}">@{{ res['username'] }}</a></li>
+    {% endfor %}
+    {% elif data["querytype"] == "post" %}
+    {% for res in data['results'] %}
+        <li><a href="/post/{{ res['pid'] }}">@{{ res['title'] }}</a></li>
+    {% endfor %}
+    {% endif %}
+    </ul>
+
+</div>
+{% endblock %}
+


### PR DESCRIPTION
You can now search for users or posts by making a POST request to /search with either the `user` or `post` argument set to your query string of choice. The query type and results are passed to the template at `data["querytype"]` and `data["results"]` respectively.

I added a very rudimentary "results" page template as an example and for debugging only, you can totally overhaul it for the front end as needed.