### PR TITLE
Fix error when redirecting to account page

### DIFF
--- a/src/templates/editable-profile-option.html
+++ b/src/templates/editable-profile-option.html
@@ -1,5 +1,5 @@
 {% macro editable_option(limits, data, option) %}
-<form method="post" action="account" class="editable-profile-option" autocomplete="off">
+<form method="post" action="/account" class="editable-profile-option" autocomplete="off">
     <label class="profile-option-label" for="{{ option }}"></label>
     <input type="{{ option }}" 
            name="{{ option }}" 


### PR DESCRIPTION
There was a missing backslash which was breaking the redirect for the account page when trying to update user information.

fixes #47 