### PR TITLE
Post editing

### DIFF
--- a/docs/template_fields.md
+++ b/docs/template_fields.md
@@ -21,7 +21,8 @@ To the post view:
     "pid":          ID of the post (int),
     "title":        title of the post (string),
     "timestamp":    timestamp of the post (string),
-    "content":      content of the post (HTML string)
+    "content":      content of the post (HTML string),
+    "raw_content":  raw content of the post (markdown string),
     "votes":        net up/downvotes of the post (int),
     "owner":        ID of the post author,
     "comments":     list of comments, which are dictionaries with the following structure:

--- a/src/server.py
+++ b/src/server.py
@@ -93,7 +93,7 @@ def user(uid):
 @app.route('/post/<pid>')
 def post(pid):
     postInfo = agoraModel.getPost(pid)
-    content = open(os.path.join(POSTDIR, postInfo['filename'])).read()
+    content = agoraFM.getPost(postInfo['filename'])
     html_content = markdown.markdown(content)
     postInfo["content"] = html_content
     g.data.update(postInfo)

--- a/src/server.py
+++ b/src/server.py
@@ -187,6 +187,12 @@ def write_post():
     agoraModel.writePost(g.sessionToken, data["title"], data["content"])
     return redirect("/account")
 
+@app.route('/edit/<pid>', methods=['POST'])
+def edit_post(pid):
+    data = request.form
+    agoraModel.editPost(g.sessionToken, pid, data["title"], data["content"])
+    return redirect(f"/post/{pid}")
+
 @app.route('/deletepost/<pid>', methods=['POST'])
 def delete_post(pid):
     agoraModel.deletePost(g.sessionToken, pid)

--- a/src/server.py
+++ b/src/server.py
@@ -93,9 +93,10 @@ def user(uid):
 @app.route('/post/<pid>')
 def post(pid):
     postInfo = agoraModel.getPost(pid)
-    content = agoraFM.getPost(postInfo['filename'])
-    html_content = markdown.markdown(content)
+    md_content = agoraFM.getPost(postInfo['filename'])
+    html_content = markdown.markdown(md_content)
     postInfo["content"] = html_content
+    postInfo["raw_content"] = md_content
     g.data.update(postInfo)
     return render_template('post.html', data=g.data)
 

--- a/src/utilities/AgoraDatabaseManager.py
+++ b/src/utilities/AgoraDatabaseManager.py
@@ -189,6 +189,9 @@ class AgoraDatabaseManager:
     def insertPost(self, uid, title, location):
         self.execute("INSERT INTO posts (owner, title, filename) VALUES (?, ?, ?)", (uid, title, location,))
 
+    def updatePost(self, pid, title):
+        self.execute("UPDATE posts SET title=? WHERE pid=?", (title, pid,))
+
     def insertImage(self, uid, title, location, accessid):
         self.execute("INSERT INTO images (owner, title, filename, accessid) VALUES (?, ?, ?, ?)", (uid, title, location, accessid,))
 

--- a/src/utilities/AgoraFileManager.py
+++ b/src/utilities/AgoraFileManager.py
@@ -1,12 +1,20 @@
 import os
+from agora_errors import *
 
 class AgoraFileManager:
     def __init__(self, postdir, imgdir):
         self.postdir = postdir
         self.imgdir = imgdir
 
+    def getPost(self, filename):
+        path = os.path.join(self.postdir, filename)
+        if os.path.isfile(path):
+            return open(path, 'r').read()
+        else:
+            raise AgoraENoSuchPost
+
     def writePost(self, filename, content):
-        path = os.path.join(self.homedir, filename)
+        path = os.path.join(self.postdir, filename)
         with open(path, 'w+') as f:
             f.write(content)
 

--- a/src/utilities/AgoraFileManager.py
+++ b/src/utilities/AgoraFileManager.py
@@ -18,6 +18,11 @@ class AgoraFileManager:
         with open(path, 'w+') as f:
             f.write(content)
 
+    def editPost(self, filename, content):
+        path = os.path.join(self.postdir, filename)
+        with open(path, 'w') as f:
+            f.write(content)
+
     def saveImage(self, filename, file):
         path = os.path.join(self.imgdir, filename)
         file.save(path)

--- a/src/utilities/AgoraInterpreterFilter.py
+++ b/src/utilities/AgoraInterpreterFilter.py
@@ -97,6 +97,11 @@ class AgoraInterpreterFilter:
         self.db.insertPost(uid, title, filename)
         self.fm.writePost(filename, content)
 
+    def editPost(self, pid, title, content):
+        filename = self.db.getPostInfo(pid)["filename"]
+        self.db.updatePost(pid, title)
+        self.fm.editPost(filename, content)
+
     def deletePost(self, pid):
         self.db.deletePost(pid)
     

--- a/src/utilities/AgoraSemanticFilter.py
+++ b/src/utilities/AgoraSemanticFilter.py
@@ -146,7 +146,17 @@ class AgoraSemanticFilter(AgoraFilter):
     def writePost(self, sessionToken, title, content):
         uid = self.do_login(sessionToken)
         return self.next.writePost(uid, title, content)
-    
+
+    def editPost(self, sessionToken, pid, title, content):
+        uid = self.do_login(sessionToken)
+        if self.db.postExists(pid) is None:
+            raise AgoraENoSuchPost
+        pinfo = self.db.getPostInfo(pid)
+        if pinfo['owner'] != uid:
+            raise AgoraENotAuthorized
+        return self.next.editPost(pid, title, content)
+           
+ 
     def deletePost(self, sessionToken, pid):
         uid = self.do_login(sessionToken)
         if self.db.postExists(pid) is None:

--- a/src/utilities/AgoraSyntacticFilter.py
+++ b/src/utilities/AgoraSyntacticFilter.py
@@ -191,7 +191,13 @@ class AgoraSyntacticFilter(AgoraFilter):
         self.validatePostTitle(title)
         self.validatePost(content)
         return self.next.writePost(sessionToken, title, content)
-    
+
+    def editPost(self, sessionToken, pid, title, content):
+        self.validateToken(sessionToken, "session")
+        self.validatePostTitle(title)
+        self.validatePost(content)
+        return self.next.editPost(sessionToken, pid, title, content)   
+ 
     def deletePost(self, sessionToken, pid):
         self.validateToken(sessionToken, "session")
         if not self.isValidId(pid):


### PR DESCRIPTION
Made the following changes:
- Raw markdown of any post is now passed to templates as `raw_content`. Note that this means the raw markdown of a general user's post is *not protected* by the layered security of the syntactic/semantic/interpreter filters. I'm okay with this, and in general, it might actually be cool if anyone could opt to view the raw markdown of anyone else's post - what do you think?
- Post content access in the server now happens through the `AgoraFileManager`
- Posts can now be edited by POSTing a `title` and `content` to `/edit/<pid>`