### PR TITLE
Add `browse/posts` and `browse/users` pages and update search functionality

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -245,16 +245,19 @@ def delete_image(imgid):
 @app.route('/search', methods=['POST'])
 def search():
     data = request.form
+    if 'user' in data:
+        get_search('user', data['user'])
+    if 'post' in data:
+        get_search('post', data['post'])
+    return render_template('search.html', data=g.data)
+
+def get_search(querytype, query):
     results = []
-    querytype = ""
-    if "user" in data:
-        querytype = "user"
-        results = agoraModel.searchUsers(data["user"])
-    if "post" in data:
-        querytype = "post"
-        results = agoraModel.searchPosts(data["post"])
-    g.data["querytype"] = querytype
-    g.data["results"] = results
-    return render_template("results.html", data=g.data)
+    if querytype == 'user':
+        results = agoraModel.searchUsers(query)
+    if querytype == 'post':
+        results = agoraModel.searchPosts(query)
+    g.data['results'] = results
+    g.data['querytype'] = querytype
 
 app.run(host = "0.0.0.0", port = PORT)

--- a/src/server.py
+++ b/src/server.py
@@ -251,6 +251,16 @@ def search():
         get_search('post', data['post'])
     return render_template('search.html', data=g.data)
 
+@app.route('/browse/users')
+def browse_users():
+    get_search('user', "")
+    return render_template('browse.html', data=g.data)
+
+@app.route('/browse/posts')
+def browse_posts():
+    get_search('post', "")
+    return render_template('browse.html', data=g.data)
+
 def get_search(querytype, query):
     results = []
     if querytype == 'user':

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -3,6 +3,7 @@
 :root {
 /* variables for use through all templates */
     --thumbnail-size: 50px;
+    --browse-button-size: 7.5em;
 }
 
 * {
@@ -18,6 +19,10 @@ hr {
     width: auto;
     display: flex;
     flex-direction: row;
+}
+
+.hbox.padded, .vbox.padded {
+    column-gap: 1em;
 }
 
 .vbox {
@@ -53,19 +58,12 @@ nav {
     display: flex;
     padding: 0.5% 2%;
     align-items: center;
-    column-gap: 1%;
+    justify-content: space-between;
     min-height: var(--thumbnail-size);
 }
 
-#home-button {
-/* TODO: surely, there is a better way to do this - but I cannot find it */
-    position: absolute;
-    left: 48%;
-}
-
-#nav-search-bar {
-    margin-left: auto;
-    /* min-width: 300px; */
+#header-login-options {
+    min-width: calc(2 * var(--browse-button-size));
 }
 
 /* login & create account */
@@ -85,7 +83,7 @@ nav {
 #login-options {
     width: 25%;
     text-align: center;
-    justify-content: space-around;
+    justify-content: space-between;
     margin: 0% 2%;
 }
 

--- a/src/templates/browse.html
+++ b/src/templates/browse.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+
+<h1>{% block title %}browse {{ data['querytype'] }}s{% endblock %}</h1>
+
+{% block content %}
+    {# posts list #}
+    <div class="group vbox padded">
+        <form method="post" action="/search">
+            <label for="post">Search {{ data['querytype'] }}s:</label>
+            <input type="text" name="{{ data['querytype'] }}">
+            <input type="submit" value="search">
+        </form>
+        <hr>
+        {% include 'results.html' %}
+    </div>
+{% endblock %}

--- a/src/templates/header.html
+++ b/src/templates/header.html
@@ -1,29 +1,35 @@
 <nav>
-    {% if data['logged_in_user'] is none -%}
-         <a href="/login">log in</a>
-    {% else -%}
-        <img class="thumbnail profile-picture"
-                {% if data['logged_in_user']['pfp'] is none  %} 
-                    src="{{ url_for('static', filename='img/default-pfp.png') }}" 
-                {% else %}
-                    src="/userimg/{{ data['logged_in_user']['pfp'] }}"
-                {% endif %}
-                alt="the user's profile picture">
-        <div class="vbox">
-            <a href="/user/{{ data['logged_in_user']['uid'] }}">
-                @{{ data['logged_in_user']['username'] }}</a>
-            <form action="/logout" method="post">
-                <input type="submit" value="logout" name="logout"></input>
-            </form>
-        </div>
-    {% endif %}
-    
-    <a id="home-button" href="/">agora</a>
-	
-    <div id="nav-search-bar">
-        <form method="post" action="/search">
-            <input type="text" id="nav-search-bar" placeholder="Search posts..." name="post"/>
+    <div id="header-login-options" class="hbox padded">
+        {% if data['logged_in_user'] is none -%}
+             <a href="/login">log in</a>
+        {% else -%}
+            <img class="thumbnail profile-picture"
+                    {% if data['logged_in_user']['pfp'] == None  %} 
+                        src="{{ url_for('static', filename='img/default-pfp.png') }}" 
+                    {% else %}
+                        src="/userimg/{{ data['logged_in_user']['pfp'] }}"
+                    {% endif %}
+                    alt="the user's profile picture">
+            <div class="vbox">
+                <a href="/user/{{ data['logged_in_user']['uid'] }}">
+                    @{{ data['logged_in_user']['username'] }}</a>
+                <form action="/logout" method="post">
+                    <input type="submit" value="logout" name="logout"></input>
+                </form>
+            </div>
+        {% endif %}
+    </div>
+    <a href="/">agora</a>
+
+    <div class="hbox padded">
+        <form action="/browse/posts" method="get">
+            <button name="post" value="" type="submit">browse posts</button>
         </form>
+        <form action="/browse/users" method="get">
+            <button name="user" value="" type="submit">browse users</button>
+        </form>
+	</div>
+
     </div>
 </nav>
 

--- a/src/templates/results.html
+++ b/src/templates/results.html
@@ -1,24 +1,28 @@
 {% extends 'base.html' %}
 
-<h1>{% block title %}tab-name-here{% endblock %}</h1>
+<h1>{% block title %}search results{% endblock %}</h1>
 
 {% block content %}
 <div class="group">
 
     <h1>Search results:</h1>
     
+    {% if data['results'] is not none %}
     <!-- TODO: replace this with a fancier image list, or even put this in another template  -->
-    <ul>
-    {% if data["querytype"] == "user" %}
-    {% for res in data['results'] %}
-        <li><a href="/user/{{ res['uid'] }}">@{{ res['username'] }}</a></li>
-    {% endfor %}
-    {% elif data["querytype"] == "post" %}
-    {% for res in data['results'] %}
-        <li><a href="/post/{{ res['pid'] }}">@{{ res['title'] }}</a></li>
-    {% endfor %}
+        <ul>
+        {% if data["querytype"] == "user" %}
+            {% for res in data['results'] %}
+                <li><a href="/user/{{ res['uid'] }}">@{{ res['username'] }}</a></li>
+            {% endfor %}
+        {% elif data["querytype"] == "post" %}
+            {% for res in data['results'] %}
+                <li><a href="/post/{{ res['pid'] }}">@{{ res['title'] }}</a></li>
+            {% endfor %}
+        {% endif %}
+        </ul>
+    {% else %}
+        <p>Nothing found.</p>
     {% endif %}
-    </ul>
 
 </div>
 {% endblock %}

--- a/src/templates/results.html
+++ b/src/templates/results.html
@@ -1,29 +1,20 @@
-{% extends 'base.html' %}
-
-<h1>{% block title %}search results{% endblock %}</h1>
-
-{% block content %}
-<div class="group">
-
-    <h1>Search results:</h1>
-    
     {% if data['results'] is not none %}
     <!-- TODO: replace this with a fancier image list, or even put this in another template  -->
-        <ul>
+        <ul class="naked-list">
         {% if data["querytype"] == "user" %}
             {% for res in data['results'] %}
                 <li><a href="/user/{{ res['uid'] }}">@{{ res['username'] }}</a></li>
             {% endfor %}
         {% elif data["querytype"] == "post" %}
             {% for res in data['results'] %}
-                <li><a href="/post/{{ res['pid'] }}">@{{ res['title'] }}</a></li>
+                <li>
+                    <a href="/post/{{ res['pid'] }}">{{ res['title'] }}</a> by 
+                    <a href="/user/{{ res['owner'] }}">@{{ res['username'] }}</a>
+                </li>
             {% endfor %}
         {% endif %}
         </ul>
     {% else %}
         <p>Nothing found.</p>
     {% endif %}
-
-</div>
-{% endblock %}
 

--- a/src/templates/search.html
+++ b/src/templates/search.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+
+<h1>{% block title %}search results{% endblock %}</h1>
+
+{% block content %}
+<div class="group">
+
+    <h1>Search results:</h1>
+    
+    {% include 'results.html' %}
+
+</div>
+{% endblock %}
+

--- a/src/utilities/AgoraDatabaseManager.py
+++ b/src/utilities/AgoraDatabaseManager.py
@@ -153,7 +153,7 @@ class AgoraDatabaseManager:
         return (None if res is None else [r for r in res])
 
     def searchPost(self, substr):
-        res = self.query("SELECT pid, title FROM posts WHERE title LIKE '%' || ? || '%' ORDER BY timestamp DESC", (substr,))
+        res = self.query("SELECT P.pid, P.title, P.owner, U.username FROM posts P JOIN users U ON P.owner = U.uid WHERE P.title LIKE '%' || ? || '%' ORDER BY timestamp DESC", (substr,))
         return (None if res is None else [r for r in res])
 
 


### PR DESCRIPTION
This PR adds two new pages with routes `/browse/posts` and `/browse/users` which stem from one page template, `browse.html`.

The header now has a button for each of these browse pages, which have replaced the search bar that was there before. Now, the search bars appear within each page, and search only for posts and users, respectively.

I've re-organized how searching is handled in the `server.py` file, abstracting most of its functionality out into a helper function that is shared between the routes for these two pages and a route for the search results page. This change is also reflected in the new `search.html` template, which is effectively taking over the role of the `results.html` template. The `results.html` template is now only for getting the results of a search *as a list*, while the `search.html` template actually shows the "search results" page (with the header "Search results:", etc.), and *includes* the `results.html` template.

The DB manager now passes the post author's UID and username to the post search results so these can be linked in the results.

Finally, I made a few small CSS changes, mainly relating to the header.