### PR TITLE
Fix the name of the `do_login` function

### DIFF
--- a/src/utilities/AgoraSemanticFilter.py
+++ b/src/utilities/AgoraSemanticFilter.py
@@ -173,7 +173,7 @@ class AgoraSemanticFilter(AgoraFilter):
         return self.next.writePost(uid, title, content)
 
     def editPost(self, sessionToken, pid, title, content):
-        uid = self.do_login(sessionToken)
+        uid = self.doLogin(sessionToken)
         if self.db.postExists(pid) is None:
             raise AgoraENoSuchPost
         pinfo = self.db.getPostInfo(pid)


### PR DESCRIPTION
This accidentally got rolled back from the previous update.