### PR TITLE
Add post writing and editing pages

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -191,7 +191,7 @@ def confirm_email(token):
 @app.route('/write')
 def new_post():
     g.data['new_post'] = True
-    return render_template('write-post.html', data=g.data)
+    return render_template('write-post.html', data=g.data, limits=INPUT_LENGTH_LIMITS)
 
 @app.route('/write', methods=['POST'])
 def write_post():
@@ -202,7 +202,7 @@ def write_post():
 @app.route('/edit/<pid>')
 def edit_post_view(pid):
     get_post_content(pid)
-    return render_template('write-post.html', data=g.data)
+    return render_template('write-post.html', data=g.data, limits=INPUT_LENGTH_LIMITS)
 
 @app.route('/edit/<pid>', methods=['POST'])
 def edit_post(pid):

--- a/src/server.py
+++ b/src/server.py
@@ -96,14 +96,17 @@ def user(uid):
 
 @app.route('/post/<pid>')
 def post(pid):
+    get_post_content(pid)
+    return render_template('post.html', data=g.data)
+
+def get_post_content(pid):
     postInfo = agoraModel.getPost(pid)
     md_content = agoraFM.getPost(postInfo['filename'])
     html_content = markdown.markdown(md_content)
     postInfo["content"] = html_content
     postInfo["raw_content"] = md_content
     g.data.update(postInfo)
-    return render_template('post.html', data=g.data)
-
+    
 @app.route('/userimg/<accessid>')
 def user_image(accessid):
     imgname = agoraModel.getImage(accessid)
@@ -185,20 +188,20 @@ def confirm_email(token):
     agoraModel.confirmEmail(token)
     return redirect("/account")
 
+@app.route('/write')
+def new_post():
+    g.data['new_post'] = True
+    return render_template('write-post.html', data=g.data)
+
 @app.route('/write', methods=['POST'])
 def write_post():
     data = request.form
-    agoraModel.writePost(g.sessionToken, data["title"], data["content"])
-    return redirect("/account")
+    pid = agoraModel.writePost(g.sessionToken, data["title"], data["content"])
+    return redirect(f'/post/{pid}')
 
 @app.route('/edit/<pid>')
 def edit_post_view(pid):
-    postInfo = agoraModel.getPost(pid)
-    md_content = agoraFM.getPost(postInfo['filename'])
-    html_content = markdown.markdown(md_content)
-    postInfo["content"] = html_content
-    postInfo["raw_content"] = md_content
-    g.data.update(postInfo)
+    get_post_content(pid)
     return render_template('write-post.html', data=g.data)
 
 @app.route('/edit/<pid>', methods=['POST'])

--- a/src/server.py
+++ b/src/server.py
@@ -191,6 +191,16 @@ def write_post():
     agoraModel.writePost(g.sessionToken, data["title"], data["content"])
     return redirect("/account")
 
+@app.route('/edit/<pid>')
+def edit_post_view(pid):
+    postInfo = agoraModel.getPost(pid)
+    md_content = agoraFM.getPost(postInfo['filename'])
+    html_content = markdown.markdown(md_content)
+    postInfo["content"] = html_content
+    postInfo["raw_content"] = md_content
+    g.data.update(postInfo)
+    return render_template('write-post.html', data=g.data)
+
 @app.route('/edit/<pid>', methods=['POST'])
 def edit_post(pid):
     data = request.form

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -155,6 +155,19 @@ nav {
     border-style: solid;
     border-color: lightgray;
     border-width: thin;
-    padding: 2%;
+    padding: 1%;
+    height: 50vh;
+    overflow: auto;
+}
+
+.post-body > textarea {
+    resize: none;
+    padding: 0%;
+    margin: 0%;
+    border: none;
+}
+
+.post-body > textarea:focus-visible {
+    outline: transparent;
 }
 

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -14,6 +14,13 @@ hr {
     border-style: dashed;
 }
 
+pre {
+/* TODO: this is a workaround for a terrible markdown.markdown behavior that turns all lines 
+   that start with an indent into pre blocks. This may not be the behavior we want when we 
+   figure out a better long-term solution for the markdown.markdown issue. */
+    white-space: pre-wrap;
+}
+
 .hbox {
 /* a box for displaying things spaced horizontally */
     width: auto;
@@ -158,16 +165,19 @@ nav {
     padding: 1%;
     height: 50vh;
     overflow: auto;
+    overflow-wrap: break-word;
 }
 
-.post-body > textarea {
+#editable-post-body {
     resize: none;
     padding: 0%;
     margin: 0%;
     border: none;
+    width: 100%;
+    height: 47vh;
 }
 
-.post-body > textarea:focus-visible {
+#editable-post-body:focus-visible {
     outline: transparent;
 }
 

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -28,15 +28,16 @@ pre {
     flex-direction: row;
 }
 
-.hbox.padded, .vbox.padded {
-    column-gap: 1em;
-}
-
 .vbox {
 /* a box for displaying things spaced vertically */
     width: auto;
     display: flex;
     flex-direction: column;
+}
+
+.hbox.padded, .vbox.padded {
+    column-gap: 1em;
+    row-gap: 1em;
 }
 
 .naked-list {
@@ -158,26 +159,32 @@ nav {
     font-style: oblique 5deg;
 }
 
-.post-body {
+.post-box {
     border-style: solid;
     border-color: lightgray;
     border-width: thin;
     padding: 1%;
-    height: 50vh;
+    height: 100%;
     overflow: auto;
     overflow-wrap: break-word;
 }
 
-#editable-post-body {
+div.post-box > textarea {
     resize: none;
     padding: 0%;
     margin: 0%;
     border: none;
     width: 100%;
+    /* TODO: this is going to be dynamically sized with js (later) */
     height: 47vh;
 }
 
-#editable-post-body:focus-visible {
+div.post-box > textarea:focus-visible {
     outline: transparent;
+}
+
+.post-box.post-title {
+    height: 1em;
+    overflow: hidden;
 }
 

--- a/src/templates/post-preview.html
+++ b/src/templates/post-preview.html
@@ -1,4 +1,0 @@
-<h1>{{ data['posts'] }}</h1>
-
-By <b>{{ data['username'] }}</b>
-

--- a/src/templates/post.html
+++ b/src/templates/post.html
@@ -14,7 +14,12 @@
     </div>
 
     <div class="post-body">
-        {{ data['content'] | safe }}
+        {% if (data['logged_in_user'] is not none) and
+              (data['logged_in_user']['uid'] == data['uid']) -%}
+            <textarea id="post-body" wrap="hard">{{ data['content'] | safe }}</textarea>
+        {% else -%}
+            {{ data['content'] | safe }}
+        {% endif %}
     </div>
 
     <p class="sub-info">Votes: {{ data['votes'] }}</p>

--- a/src/templates/post.html
+++ b/src/templates/post.html
@@ -3,35 +3,41 @@
 <h1>{% block title %}{{ data['title'] }}{% endblock %}</h1>
 
 {% block content %}
-
 <div class="group">
 
     <h1>{{ data['title'] }}</h1>
 
-    <div class="sub-info">
-        <a class="author" href="/user/{{ data['owner'] }}">@{{ data['username'] }}</a>
-        <p class="timestamp">{{ data['timestamp'] }}</p>
-    </div>
+    <div class="vbox padded">
+        <div class="sub-info">
+            <a class="author" href="/user/{{ data['owner'] }}">@{{ data['username'] }}</a>
+            <p class="timestamp">{{ data['timestamp'] }}</p>
+            
+            {# If the logged in user is the author, an edit button will appear #}
+            {% if (data['logged_in_user'] is not none) and
+                  (data['logged_in_user']['uid'] == data['owner']) -%}
+                <form method="get" action="/edit/{{ data['pid'] }}">
+                    <input type="submit" value="edit post">
+                </form>
+            {% endif %}
+        </div>
 
-    <div class="post-body">
-        {% if (data['logged_in_user'] is not none) and
-              (data['logged_in_user']['uid'] == data['uid']) -%}
-            <textarea id="post-body" wrap="hard">{{ data['content'] | safe }}</textarea>
-        {% else -%}
+        <div class="post-box">
             {{ data['content'] | safe }}
-        {% endif %}
+        </div>
+        
+        <p class="sub-info">Votes: {{ data['votes'] }}</p>
+
+        <h2>Comments:</h2>
+        <ul class="naked-list">
+            {% for c in data['comments'] %}
+                <li>
+                    <a href="/user/{{ c['uid'] }}"><b>@{{ c['username'] }}</b></a>: 
+                        &nbsp; {{ c['content'] }}
+                </li>
+            {% endfor %}
+        </ul>
     </div>
-
-    <p class="sub-info">Votes: {{ data['votes'] }}</p>
-
-    <h2>Comments:</h2>
-    <ul class="naked-list">
-    {% for c in data['comments'] %}
-    <li><a href="/user/{{ c['uid'] }}"><b>@{{ c['username'] }}</b></a>: &nbsp; {{ c['content'] }}</li>
-    {% endfor %}
-    </ul>
 
 </div>
-
 {% endblock %}
 

--- a/src/templates/profile.html
+++ b/src/templates/profile.html
@@ -36,6 +36,7 @@
 
         {# posts list #}
         <div class="group">
+            <form method="get" action="/write"><input type="submit" value="new post"></form>
             <h2>Posts: {{ data['posts'] | length }}</h2>
             <ul class="naked-list">
             {% for post in data['posts'] %}

--- a/src/templates/write-post.html
+++ b/src/templates/write-post.html
@@ -1,0 +1,11 @@
+{% extends 'base.html' %}
+
+<h1>{% block title %}write post{% endblock %}</h1>
+
+{% block content %}
+    <div class="group">
+
+    
+
+    </div>
+{% endblock %}

--- a/src/templates/write-post.html
+++ b/src/templates/write-post.html
@@ -8,12 +8,19 @@
     <div class="vbox padded">
         <div class="post-box post-title">
             <textarea form="editable-post-form" 
-                      name="title">{{ data['title'] }}</textarea>
+                      name="title"
+                      minlength="{{ limits['post-title'][0] }}"
+                      maxlength="{{ limits['post-title'][1] }}"
+                      required
+                      >{{ data['title'] }}</textarea>
         </div>
 
         <div class="post-box">
             <textarea form="editable-post-form" 
-                      name="content">{{ data['raw_content'] }}</textarea>
+                      name="content"
+                      minlength="{{ limits['post-body'][0] }}"
+                      maxlength="{{ limits['post-body'][1] }}"
+                      >{{ data['raw_content'] }}</textarea>
         </div>
         
         <form id="editable-post-form" 

--- a/src/templates/write-post.html
+++ b/src/templates/write-post.html
@@ -1,11 +1,32 @@
 {% extends 'base.html' %}
 
-<h1>{% block title %}write post{% endblock %}</h1>
+<h1>{% block title %}{{ data['title'] }}{% endblock %}</h1>
 
 {% block content %}
-    <div class="group">
+<div class="group">
 
-    
+    <div class="vbox padded">
+        <div class="post-box post-title">
+            <textarea form="editable-post-form" 
+                      name="title">{{ data['title'] }}</textarea>
+        </div>
 
+        <div class="post-box">
+            <textarea form="editable-post-form" 
+                      name="content">{{ data['raw_content'] }}</textarea>
+        </div>
+        
+        <form id="editable-post-form" 
+            method="post" 
+            {% if data['new_post'] %}
+                action="/write"
+            {% else %}
+                action="/edit/{{ data['pid'] }}"
+            {% endif %}>
+            <input type="submit" value="post">
+        </form>
     </div>
+    
+</div>
 {% endblock %}
+

--- a/src/utilities/AgoraDatabaseManager.py
+++ b/src/utilities/AgoraDatabaseManager.py
@@ -205,6 +205,7 @@ class AgoraDatabaseManager:
 
     def insertPost(self, uid, title, location):
         self.execute("INSERT INTO posts (owner, title, filename) VALUES (?, ?, ?)", (uid, title, location,))
+        return self.query("SELECT pid FROM posts WHERE filename=?", (location,))[0]["pid"]
 
     def updatePost(self, pid, title):
         self.execute("UPDATE posts SET title=? WHERE pid=?", (title, pid,))

--- a/src/utilities/AgoraInterpreterFilter.py
+++ b/src/utilities/AgoraInterpreterFilter.py
@@ -94,8 +94,9 @@ class AgoraInterpreterFilter:
 
     def writePost(self, uid, title, content):
         filename = f"post{self.generateToken('postid')}.md"
-        self.db.insertPost(uid, title, filename)
+        pid = self.db.insertPost(uid, title, filename)
         self.fm.writePost(filename, content)
+        return pid
 
     def editPost(self, pid, title, content):
         filename = self.db.getPostInfo(pid)["filename"]


### PR DESCRIPTION
This PR adds two new functionalities - writing new posts and editing existing posts - both of which operate within the new `write-post.html` template.

There is a new button on the profile page which allows a user to write a new post, and clicking on any existing post now gives the user an "edit post" button if they are the author of the post they're viewing. 

Editing/writing a new post functions within the limits set in the limits dict in the parameters file. This means the user will be limited from writing a post title or body that is too long, and also too short. The title field is required, but the body is not.

After editing a post or creating a new post, the user is redirected to the page for viewing their post. This required a change in the data manager, interpreter, and server to return the PID after inserting a post.

Issues:
Currently, scrolling for the edit post view is restricted to within the box, which feels ugly. I am going to fix this when I overhaul a few existing template functionalities with js in a later PR. However, everything functions as expected, it's just not pretty.