### PR TITLE
mailgun is now used for emailing, rather than gmail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,5 @@ COPY ./src/params/ $AP/params/
 
 WORKDIR $AP
 
-CMD ["sh", "-c", "python3 server.py ${PORT} \"${GMAIL_KEY}\" ${HOST} ${RECAPTCHA_SITEKEY} ${RECAPTCHA_SERVERKEY}"]
+CMD ["sh", "-c", "python3 server.py ${PORT} \"${MAILGUN_KEY}\" ${HOST} ${RECAPTCHA_SITEKEY} ${RECAPTCHA_SERVERKEY}"]
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ sudo docker run -p 8080:8080 \
                 -v ./src/templates:/app/templates \
                 -v ./src/static:/app/static \
                 -e HOST="<THE DOMAIN YOU ARE USING>" \
-                -e GMAIL_KEY="<YOUR GMAIL KEY>" \
+                -e MAILGUN_KEY="<YOUR MAILGUN KEY>" \
                 -e RECAPTCHA_SITEKEY="<YOUR RECAPTCHA SITEKEY>" \
                 -e RECAPTCHA_SERVERKEY="<YOUR RECAPTCHA SERVERKEY>" \
                 <YOUR_NAME>/agora-app:latest

--- a/src/server.py
+++ b/src/server.py
@@ -17,7 +17,7 @@ from AgoraEmailer import *
 from AgoraFileManager import *
 
 PORT = sys.argv[1]
-GMAIL_KEY = sys.argv[2]
+MAILGUN_KEY = sys.argv[2]
 HOST = sys.argv[3]
 RECAPTCHA_SITEKEY = sys.argv[4]
 RECAPTCHA_SERVERKEY = sys.argv[5]
@@ -32,7 +32,7 @@ agoraDB = AgoraDatabaseManager("./volumes/agora.db")
 agoraSemantics.setDBManager(agoraDB)
 agoraInterpreter.setDBManager(agoraDB)
 
-agoraEmail = AgoraEmailer("agoradevel@gmail.com", GMAIL_KEY)
+agoraEmail = AgoraEmailer(MAILGUN_KEY, HOST)
 agoraInterpreter.setEmailer(agoraEmail)
 
 agoraFM = AgoraFileManager(POSTDIR, IMGDIR)

--- a/src/utilities/AgoraEmailer.py
+++ b/src/utilities/AgoraEmailer.py
@@ -1,24 +1,23 @@
 import sys
-import smtplib
-from email.message import EmailMessage
+# import smtplib
+import requests
+from requests.auth import HTTPBasicAuth 
+# from email.message import EmailMessage
 
 class AgoraEmailer:
-    def __init__(self, username, password):
-        self.username = username
+    def __init__(self, password, host):
         self.password = password
-
-    def auth(self):
-        server = smtplib.SMTP("smtp.gmail.com", 587)
-        server.ehlo()
-        server.starttls()
-        server.login(self.username, self.password)
-        return server
+        self.host = host
 
     def sendEmail(self, receiver, subject, message):
-        message = f"From: {self.username}\nTo: {receiver}\nSubject: {subject}\n\n{message}"
-        server = self.auth()
-        server.sendmail(self.username, receiver, message)
-        server.close()
+        auth = HTTPBasicAuth('api', self.password)
+        form = {
+            "from": f"Agora Gods <postmaster@{self.host}>",
+            "to": receiver,
+            "subject": subject,
+            "text": message
+        }
+        res = requests.post(f"https://api.mailgun.net/v3/{self.host}/messages", auth=auth, data=form)
 
     def confirmAccountEmail(self, receiver, url):
         subject = "Confirm your Agora account"


### PR DESCRIPTION
Note the revised Docker run instructions in `README.md`. You will now need a Mailgun API key to run the app rather than a Gmail key. (Ping me privately for this.)