### PR TITLE
Image upload interface

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -95,7 +95,7 @@ def users():
 @app.route('/user/<uid>')
 def user(uid):
     userInfo = {}
-    if g.data['logged_in_user'] is None or uid != g.data['logged_in_user']['uid']:
+    if g.data['logged_in_user'] is None or uid != str(g.data['logged_in_user']['uid']):
         userInfo = agoraModel.getUser(uid)
     else:
         userInfo = agoraModel.getMyUser(g.sessionToken)
@@ -221,7 +221,7 @@ def edit_post(pid):
 @app.route('/deletepost/<pid>', methods=['POST'])
 def delete_post(pid):
     agoraModel.deletePost(g.sessionToken, pid)
-    return redirect("/account")
+    return redirect("/files")
 
 @app.route('/comment/<pid>', methods=['POST'])
 def write_comment(pid):
@@ -272,16 +272,30 @@ def dislike_post(pid):
     return redirect(f"/post/{pid}")
 
 @app.route('/upload', methods=['POST'])
-def upload_image():
+def upload_image_post():
     imgData = request.files['file']
-    title = imgData.filename
-    return agoraModel.uploadImage(g.sessionToken, title, imgData)
-##    return redirect('/account')
+    data = request.form
+    title = data['title']
+    imgID = agoraModel.uploadImage(g.sessionToken, title, imgData)
+    return redirect(f'/userimg/{imgID}')
+
+@app.route('/upload')
+def upload_image_get():
+    return render_template('upload.html', data=g.data)
+
+@app.route('/files')
+def files():
+    if g.data['logged_in_user'] is None:
+        return redirect('/')
+    userInfo = agoraModel.getMyUser(g.sessionToken)
+    g.data.update(userInfo)
+    return render_template('files.html', data=g.data)
+    
 
 @app.route('/deleteimg/<imgid>', methods=['POST'])
 def delete_image(imgid):
     agoraModel.deleteImage(g.sessionToken, imgid)
-    return redirect('/account')
+    return redirect('/files')
 
 @app.route('/search', methods=['POST'])
 def search():

--- a/src/server.py
+++ b/src/server.py
@@ -275,8 +275,8 @@ def dislike_post(pid):
 def upload_image():
     imgData = request.files['file']
     title = imgData.filename
-    agoraModel.uploadImage(g.sessionToken, title, imgData)
-    return redirect('/account')
+    return agoraModel.uploadImage(g.sessionToken, title, imgData)
+##    return redirect('/account')
 
 @app.route('/deleteimg/<imgid>', methods=['POST'])
 def delete_image(imgid):

--- a/src/static/css/style.css
+++ b/src/static/css/style.css
@@ -14,6 +14,16 @@ hr {
     border-style: dashed;
 }
 
+h2 {
+    padding: 0%;
+    margin: 0%;
+}
+
+h3 {
+    padding: 0%;
+    margin: 0%;
+}
+
 pre {
 /* TODO: this is a workaround for a terrible markdown.markdown behavior that turns all lines 
    that start with an indent into pre blocks. This may not be the behavior we want when we 
@@ -26,6 +36,11 @@ pre {
     width: auto;
     display: flex;
     flex-direction: row;
+
+    /*
+    border-style: solid;
+    border-color: orange;
+    */
 }
 
 .vbox {
@@ -33,6 +48,11 @@ pre {
     width: auto;
     display: flex;
     flex-direction: column;
+
+    /*
+    border-style: solid;
+    border-color: blue;
+    */
 }
 
 .padded {
@@ -40,14 +60,25 @@ pre {
     row-gap: 1em;
 }
 
-.vbox.centered {
-/* TODO: mostly untested */
+.centered {
     text-align: center;
     align-items: center;
     justify-content: center;
 }
 
-.hbox.centered {
+.hbox.h-centered {
+    justify-content: center;
+}
+
+.hbox.v-centered {
+    align-items: center;
+}
+
+.vbox.v-centered {
+    justify-content: center;
+}
+
+.vbox.h-centered {
     align-items: center;
 }
 
@@ -83,6 +114,11 @@ pre {
 
 .group {
     margin: 2%;
+
+    /*
+    border-style: solid;
+    border-color: green;
+    */
 }
 
 /* header */

--- a/src/templates/browse.html
+++ b/src/templates/browse.html
@@ -10,7 +10,7 @@
             <input type="text" name="{{ data['querytype'] }}">
             <input type="submit" value="search">
         </form>
-        <hr>
+        <h1>All {{ data['querytype'] }}s:</h1>
         {% include 'results.html' %}
     </div>
 {% endblock %}

--- a/src/templates/comment-section.html
+++ b/src/templates/comment-section.html
@@ -21,7 +21,7 @@
         <li><div class="vbox text-box">
 
             {# comment header #}
-            <div class="hbox padded centered">
+            <div class="hbox padded v-centered">
                 <a href="/user/{{ c['uid'] }}">@{{ c['username'] }}</a>
                 <p>{{ c['timestamp'] }}</p>
                 {# If the logged in user is the author, a delete button will appear #}

--- a/src/templates/files.html
+++ b/src/templates/files.html
@@ -1,0 +1,29 @@
+{% import 'manage-files.html' as files %}
+{% extends 'base.html' %}
+
+<h1>{% block title %}manage files{% endblock %}</h1>
+
+{% block content %}
+
+<div class="group vbox padded">
+    {# images list #}
+    <div class="vbox padded">
+        <div class="hbox padded v-centered">
+            <h2>Images: {{ data['images'] | length }}</h2>
+            {{ files.new_image_button() }}
+        </div>
+        {{ files.image_list(data['images']) }}
+    </div>
+    
+    {# posts list #}
+    <div class="vbox padded">
+        <div class="hbox padded v-centered">
+            <h2>Posts: {{ data['posts'] | length }}</h2>
+            {{ files.new_post_button() }}
+        </div>
+        {{ files.private_post_list(data) }}
+    </div>
+</div> 
+
+ {% endblock %}
+

--- a/src/templates/manage-files.html
+++ b/src/templates/manage-files.html
@@ -1,0 +1,53 @@
+{% macro manage_files_button() %}
+    <form method="get" action="/files"><input type="submit" value="manage"></form>
+{% endmacro %}
+
+
+{% macro new_post_button() %}
+    <form method="get" action="/write"><input type="submit" value="new post"></form>
+{% endmacro %}
+
+
+{% macro new_image_button() %}
+    <form method="get" action="/upload"><input type="submit" value="new image"></form>
+{% endmacro %}
+
+
+{% macro image_list(images) %}
+    <ul class="naked-list">
+    {% for image in images %}
+        <li>
+            <div class="hbox padded">
+                <form method="post" action="/deleteimg/{{ image['accessid'] }}">
+                    <input type="submit" value="X">
+                </form>
+            <a href="/userimg/{{ image['accessid'] }}">{{ image['title'] }}</a>
+            </div>
+        </li>
+    {% endfor %}
+    </ul>
+{% endmacro %}
+
+
+{% macro public_post_list(posts) %}
+    <ul class="naked-list">
+    {% for post in posts %}
+        <li><a href="/post/{{ post['pid'] }}">{{ post['title'] }}</a></li>
+    {% endfor %}
+    </ul>
+{% endmacro %}
+
+{% macro private_post_list(data) %}
+    <ul class="naked-list">
+    {% for post in data['posts'] %}
+        <li>
+            <div class="hbox padded">
+                <form method="post" action="/deletepost/{{ post['pid'] }}">
+                    <input type="submit" value="X">
+                </form>
+                <a href="/post/{{ post['pid'] }}">{{ post['title'] }}</a>
+            </div>
+        </li>
+    {% endfor %}
+    </ul>
+{% endmacro %}

--- a/src/templates/profile.html
+++ b/src/templates/profile.html
@@ -1,60 +1,68 @@
-{% from 'editable-profile-option.html' import editable_option with context %}
+{% from 'editable-profile-option.html' import editable_option %}
+{% import 'manage-files.html' as files %}
+
 {% extends 'base.html' %}
 
 <h1>{% block title %}{{ data['username'] }} {% endblock %}</h1>
 
 {% block content %}
 
-<div class="hbox">
-    <div id="profile-post-stack" class="vbox">
-        {# profile info area #}
-        <div class="group hbox">
-            <img class="small-img profile-picture"
-            {# TODO: this should be changed so that the def pfp is assigned at acct creation #}
-                 {% if data['pfp'] is none %}
-                 src="{{ url_for('static', filename='img/default-pfp.png') }}" 
-                 {% else %}
-                 src="/userimg/{{ data['pfp'] }}"
-                 {% endif %}
-                 alt="the user's profile picture">
-            <ul id="profile-options" class="naked-list group">
-                {% if (data['logged_in_user'] is not none) and
-                      (data['logged_in_user']['uid'] == data['uid']) -%}
-                    <li class="hbox username-main">
-                        @{{ editable_option(limits, data['logged_in_user'], "username") }}</li>
-                    <li class="option-main status-main">
-                        {{ editable_option(limits, data['logged_in_user'], "status") }}</li>
-                    <li class="option-main requires-confirmation">
-                        {{ editable_option(limits, data['logged_in_user'], "email") }}</li>
-                    <li class="option-main requires-confirmation">
-                        {{ editable_option(limits, data['logged_in_user'], "password") }}</li>
-                {% else -%}
-                    <li class="username-main">@{{ data['username'] }}</li>
-                    <li class="status-main">{{ data['status'] }}</li>
-                {% endif %}
-            </ul>
+{# whether the profile is the logged in user's own profile #}
+{% set self = (data['logged_in_user'] is not none) and 
+              (data['logged_in_user']['uid'] == data['uid']) %}
+
+<div class="group">
+    <div class="hbox padded">
+        <div id="profile-post-stack" class="vbox padded">
+            {# profile info area #}
+            <div class="hbox padded">
+                <img class="small-img profile-picture"
+                     {% if data['pfp'] is none %}
+                         src="{{ url_for('static', filename='img/default-pfp.png') }}" 
+                     {% else %}
+                         src="/userimg/{{ data['pfp'] }}"
+                     {% endif %}
+                     alt="the user's profile picture">
+                <ul class="naked-list">
+                    {% if self %}
+                        <li class="hbox username-main">
+                            @{{ editable_option(limits, data, "username") }}</li>
+                        <li class="option-main status-main">
+                            {{ editable_option(limits, data, "status") }}</li>
+                        <li class="option-main requires-confirmation">
+                            {{ editable_option(limits, data, "email") }}</li>
+                        <li class="option-main requires-confirmation">
+                            {{ editable_option(limits, data, "password") }}</li>
+                    {% else %}
+                        <li class="username-main">@{{ data['username'] }}</li>
+                        <li class="status-main">{{ data['status'] }}</li>
+                    {% endif %}
+                </ul>
+            </div>
+
+            {# posts list #}
+            <div class="vbox padded">
+                <h2>Posts: {{ data['posts'] | length }}</h2>
+                {{ files.public_post_list(data['posts']) }}
+            </div>
+
+            {% if self %}
+            <div class="hbox padded v-centered">
+                <h3>Manage posts and images:</h3>
+                {{ files.manage_files_button() }}
+            </div>
+            {% endif %}
         </div>
 
-        {# posts list #}
-        <div class="group">
-            <form method="get" action="/write"><input type="submit" value="new post"></form>
-            <h2>Posts: {{ data['posts'] | length }}</h2>
+        {# friends list #}
+        <div class="vbox padded">
+            <h2>Friends: {{ data['friends'] | length }}</h2>
             <ul class="naked-list">
-            {% for post in data['posts'] %}
-                <li><a href="/post/{{ post['pid'] }}">{{ post['title'] }}</a></li>
+            {% for (uid, name) in data['friends'] %}
+                <li><a href="/user/{{ uid }}">@{{ name }}</a></li>
             {% endfor %}
             </ul>
         </div>
-    </div>
-
-    {# friends list #}
-    <div id="friend-list" class="group">
-        <h2>Friends: {{ data['friends'] | length }}</h2>
-        <ul class="naked-list">
-        {% for (uid, name) in data['friends'] %}
-            <li><a href="/user/{{ uid }}">@{{ name }}</a></li>
-        {% endfor %}
-        </ul>
     </div>
 </div>
 

--- a/src/templates/upload.html
+++ b/src/templates/upload.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+
+<h1>{% block title %}upload{% endblock %}</h1>
+
+{% block content %}
+
+<div class="group">
+   <h1>Upload a new image:</h1>
+    <form method="post" action="/upload" enctype="multipart/form-data">
+        <input type="file" name="file">
+        <label for="title">Title:</label>
+        <input type="text" name="title" value="" required />
+        <button>upload</button>
+    </form>
+</div>
+
+{% endblock %}

--- a/src/templates/write-post.html
+++ b/src/templates/write-post.html
@@ -1,11 +1,17 @@
+{% import 'manage-files.html' as files %}
+
 {% extends 'base.html' %}
 
 <h1>{% block title %}{{ data['title'] }}{% endblock %}</h1>
 
 {% block content %}
-<div class="group">
 
+<div class="group">
     <div class="vbox padded">
+        <div class="hbox padded">
+            <h3>Manage posts and images:</h3>
+            {{ files.manage_files_button() }}
+        </div>
         <div class="post-box post-title">
             <textarea form="editable-post-form" 
                       name="title"
@@ -23,8 +29,7 @@
                       >{{ data['raw_content'] }}</textarea>
         </div>
         
-        <form id="editable-post-form" 
-            method="post" 
+        <form id="editable-post-form" method="post" 
             {% if data['new_post'] %}
                 action="/write"
             {% else %}
@@ -33,7 +38,7 @@
             <input type="submit" value="post">
         </form>
     </div>
-    
 </div>
+
 {% endblock %}
 

--- a/src/utilities/AgoraDatabaseManager.py
+++ b/src/utilities/AgoraDatabaseManager.py
@@ -22,7 +22,9 @@ class AgoraDatabaseManager:
         self.conn.commit()
 
     def cur(self):
-        return self.conn.cursor()
+        cur = self.conn.cursor()
+        cur.row_factory = dict_factory
+        return cur
 
     def pool_query(self, query, args=()):
         cur = self.cur().execute(query, args)

--- a/src/utilities/AgoraDatabaseManager.py
+++ b/src/utilities/AgoraDatabaseManager.py
@@ -87,13 +87,25 @@ class AgoraDatabaseManager:
         return (None if res is None else res[0]['data'])
 
 
+    
+    def getFriends(self, uid): 
+        res = self.query("SELECT F.user1, F.user2, U1.username as username1, U2.username as username2 FROM friendships F join users U1 on U1.uid = F.user1 join users U2 on U2.uid = F.user2 WHERE (user1 = ? OR user2 = ?) AND accepted = 1", (uid, uid,)) 
+        return [] if res is None else [(tup['user1'], tup['username1']) if tup['user1'] != uid else (tup['user2'], tup['username2']) for tup in res] 
+    
+    def getFriendReqsFromMe(self, uid): 
+        res = self.query("SELECT F.user1, F.user2, U1.username as username1, U2.username as username2 FROM friendships F join users U1 on U1.uid = F.user1 join users U2 on U2.uid = F.user2 WHERE user1 = ? AND accepted = 0", (uid,)) 
+        return [] if res is None else [(tup['user2'], tup['username2']) for tup in res] 
+
+    def getFriendReqsForMe(self, uid): 
+        res = self.query("SELECT F.user1, F.user2, U1.username as username1, U2.username as username2 FROM friendships F join users U1 on U1.uid = F.user1 join users U2 on U2.uid = F.user2 WHERE user2 = ? AND accepted = 0", (uid,)) 
+        return [] if res is None else [(tup['user1'], tup['username1']) for tup in res] 
+
     def getPublicUser(self, uid):
         res = self.query("SELECT uid, username, pfp, status, suspended FROM users WHERE uid = ?", (uid,))
         info = res[0]
         res = self.query("SELECT pid, title FROM posts WHERE owner = ?", (uid,))
         info["posts"] = [] if res is None else [post for post in res]
-        res = self.query("SELECT F.user1, F.user2, U1.username as username1, U2.username as username2 FROM friendships F join users U1 on U1.uid = F.user1 join users U2 on U2.uid = F.user2 WHERE (user1 = ? OR user2 = ?) AND accepted = 1", (uid, uid,))
-        info["friends"] = [] if res is None else [(tup['user1'], tup['username1']) if tup['user1'] != uid else (tup['user2'], tup['username2']) for tup in res] 
+        info["friends"] = self.getFriends(uid)
         return info
 
     def getUserLastAction(self, uid):        
@@ -126,12 +138,9 @@ class AgoraDatabaseManager:
         res = self.query("SELECT pid, title FROM posts WHERE owner = ?", (uid,))
         info["posts"] = [] if res is None else [post for post in res]
         
-        res = self.query("SELECT user1, user2 FROM friendships WHERE (user1 = ? OR user2 = ?) AND accepted = 1", (uid, uid,))
-        info["friends"] = [] if res is None else [tup['user1'] if tup['user1'] != uid else tup['user2'] for tup in res]
-        res = self.query("SELECT user2 FROM friendships WHERE user1 = ? AND accepted = 0", (uid,))
-        info["fromyou"] = [] if res is None else [r['user2'] for r in res]
-        res = self.query("SELECT user1 FROM friendships WHERE user2 = ? AND accepted = 0", (uid,))
-        info["foryou"] = [] if res is None else [r['user1'] for r in res]
+        info["friends"] = self.getFriends(uid)
+        info["fromyou"] = self.getFriendReqsFromMe(uid)
+        info["foryou"] = self.getFriendReqsForMe(uid)
 
         res = self.query("SELECT accessid, title FROM images WHERE owner = ?", (uid,))
         info["images"] = [] if res is None else [img for img in res]

--- a/src/utilities/AgoraInterpreterFilter.py
+++ b/src/utilities/AgoraInterpreterFilter.py
@@ -31,7 +31,7 @@ class AgoraInterpreterFilter:
             uid = self.db.createUser(emailAddress, username, hpassword, hrecovery)
             confirm = self.generateToken("creation")
             confirmUrl = f'{self.host}/join/{confirm}'
-            self.eml.confirmAccountEmail(emailAddress, confirmUrl)
+            self.eml.confirmAccountEmail(emailAddress, confirmUrl, recovery)
             self.db.createToken(uid, confirm, "creation")
     
     def confirmCreate(self, uid, creationToken):


### PR DESCRIPTION
This PR adds image uploading capabilities to the front end, as well as some cleanup and bug fixes.

New features:
* `server.py` has a new route `/files` which goes to a page created with the new `files.html` template. Here users can view and delete their posts and images.
* There is a new template `manage-files.html` which houses macros related to file management so they can be referenced in additional locations beyond the `/files` page.
* There is a template for the `/upload` route now, `upload.html`, which provides an interface for uploading an image.
* `profile.html` and `write-post.html` now include a button which allows users to reach the `/files` page to manage their images/posts.

Misc changes:
* `server.py` had a bug which always sent public user data instead of private user data d.t. a casting error, this has been fixed.
*  `AgoraDatabaseManager.py` had some cleanup d.t. previous `server.py` bug.
* Minor bug fix in `AgoraInterpreterFilter.py`.
* `style.css` has been updated and slightly tweaked. Due to these tweaks I also updated `browse.html` and `comment-section.html`.
* `profile.html` has had some re-working and cleanup that makes it look like more changes occurred than actually did.