### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ sudo docker run -p 8080:8080 \
                 -e MAILGUN_KEY="<YOUR MAILGUN KEY>" \
                 -e RECAPTCHA_SITEKEY="<YOUR RECAPTCHA SITEKEY>" \
                 -e RECAPTCHA_SERVERKEY="<YOUR RECAPTCHA SERVERKEY>" \
-                -e DEV_EMAILS="<LIST OF DEVELOPER EMAILS>"
+                -e DEV_EMAILS="<LIST OF DEVELOPER EMAILS>" \
                 <YOUR_NAME>/agora-app:latest
 ```
 Notes:


### PR DESCRIPTION
The instruction to build the docker image is missing a backslash.