### PR TITLE
Add new post in home page

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ sudo docker run -p 8080:8080 \
                 -e MAILGUN_KEY="<YOUR MAILGUN KEY>" \
                 -e RECAPTCHA_SITEKEY="<YOUR RECAPTCHA SITEKEY>" \
                 -e RECAPTCHA_SERVERKEY="<YOUR RECAPTCHA SERVERKEY>" \
-                -e DEV_EMAILS="<LIST OF DEVELOPER EMAILS>"
+                -e DEV_EMAILS="<LIST OF DEVELOPER EMAILS>" \
                 <YOUR_NAME>/agora-app:latest
 ```
 Notes:

--- a/src/templates/header.html
+++ b/src/templates/header.html
@@ -25,6 +25,9 @@
         alt="the agora logo"></a>
 
     <div class="hbox padded">
+        <form action="/write" method="get">
+            <button name="new_post" value="" type="submit">new post</button>
+        </form>
         <form action="/browse/posts" method="get">
             <button name="post" value="" type="submit">browse posts</button>
         </form>


### PR DESCRIPTION
The current procedure for writing a new post requires the user to
go to their account, manage post, and then post a new post.

I think adding new posts is a common action that should be
easy to access from the home page.