### PR TITLE
Fix null error when using invalid cookie

### DIFF
--- a/src/utilities/AgoraDatabaseManager.py
+++ b/src/utilities/AgoraDatabaseManager.py
@@ -145,7 +145,7 @@ class AgoraDatabaseManager:
 
     def isUserSuspended(self, uid):
         res = self.query("SELECT suspended FROM users WHERE uid = ?", (uid,))
-        return (res[0]['suspended'] == 1)
+        return (res[0]['suspended'] == 1) if res is not None else False
     
     def isUserConfirmed(self, uid):
         res = self.query("SELECT confirmed FROM users WHERE uid = ?", (uid,))
@@ -157,6 +157,8 @@ class AgoraDatabaseManager:
 
     def getPrivateUser(self, uid, concise=False):
         res = self.query("SELECT uid, username, email, pfp, status, suspended, admin FROM users WHERE uid = ?", (uid,))
+        if res is None:
+            return
         info = res[0]
         if concise:
             return info


### PR DESCRIPTION
Fixes a bug (undocumented) that caused a null indexing error when the user has an invalid cookie. I didn't find anywhere else where this might be an issue, but it's possible that it may persist in other places.