### PR TITLE
Fix email reset

### DIFF
--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -1,19 +1,34 @@
 'use strict';
 
 /**
- * These actions will be carried out when the page is finished loading.
+ * These actions will be carried out when the page is finished loading. This setup will likely
+ * be changed in the future, but it's working for now on a small scale.
  */
 document.addEventListener('DOMContentLoaded', function() {
     setUpPostEditing();
     verifyInputMatch();
+    updatePasswordCheck();
 }, false);
 
-/*
-Goal: create a "confirmation" field that will be used when a user is entering important 
-      information (such as their email or password) that we want to verify is the same 
-      information entered both times.
-*/
+/**
+ * This function makes a password verification field appear if the user is trying to update 
+ * their email. This can be further abstracted in the future.
+ */
+function updatePasswordCheck() {
+    const emailForm = document.getElementById('update-existing-email');
+    if(emailForm) {
+        const passwordField = document.getElementById('password-field');
+        passwordField.style.setProperty('display', 'none');
+        emailForm.addEventListener('input', () => {
+            passwordField.style.setProperty('display', 'block');
+        });
+    }
+}
 
+/**
+ * This function enables the behavior of the password confirmation field if on the account
+ * creation page. This can be further abstracted in the future.
+ */
 function verifyInputMatch() {
     const ogField = document.getElementById('password');
     const cnfField = document.getElementById('password-confirm');
@@ -32,10 +47,9 @@ function verifyInputMatch() {
     }
 }
 
-
 /**
- * This function will check if the page has elements to indicate that we are writing or editing 
- * a post, and if so, will set up localStorage to save the progress of the post during editing. 
+ * This function will check if the page has elements to indicate that we are writing or editing
+ * a post, and if so, will set up localStorage to save the progress of the post during editing.
  * The post area will also be populated with any currently associated localStorage values.
  */
 function setUpPostEditing() {

--- a/src/templates/form.html
+++ b/src/templates/form.html
@@ -259,11 +259,19 @@
 
 
 {# general and helpers #}
-{% macro update_existing_form(limits, data, option, target) %}
-<form method="post" action="{{ target }}" autocomplete="off">
-    <div class="hbox padded v-centered">
-        {{ field(option, limits) }}
-        <div><input type="submit" value="update"></div>
+{% macro update_existing_form(limits, data, option, target, password) %}
+<form id="update-existing-{{ option }}" method="post" action="{{ target }}" autocomplete="off">
+    <div class="vbox">
+        <div class="hbox padded v-centered">
+            {{ field(option, limits) }}
+            <div><input type="submit" value="update"></div>
+            {% if password %}
+                <p>(password required)</p>
+            {% endif %}
+        </div>
+        {% if password %}
+            {{ field('password', limits) }}
+        {% endif %}
     </div>
 </form>
 {% endmacro %}
@@ -296,7 +304,7 @@
 {% endmacro %}
 
 {% macro field(type, limits, verify) %}
-<div class="input-field">
+<div id="{{ type }}-field" class="input-field">
     <label for="{{ type }}">{{ ('confirm %s:' % type) if verify else ('%s:' % type) }}</label>
     <input type="{{ type }}" 
            name="{{ type }}"

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -11,7 +11,7 @@
     <h1>Settings for {{ data['username'] }}:</h1>
     <div class="vbox padded">
         {{ forms.update_existing_form(limits, data, 'username', '/account') }}
-        {{ forms.update_existing_form(limits, data, 'email', '/account') }}
+        {{ forms.update_existing_form(limits, data, 'email', '/account', true) }}
         {{ forms.request_password_reset_email_implicit(data) }}
         {{ files.manage_files_button() }}
         <a href="/leave"><button>delete account</button></a>


### PR DESCRIPTION
The email reset functionality broke when we began requiring passwords for email resetting. This fixes that issue!

fixes #126 

@franklindyer Please do not merge this until the js PR (#123) is merged in. I will mark this as a draft until that is merged.