### PR TITLE
Improve timestamp formatting

### DIFF
--- a/src/static/js/main.js
+++ b/src/static/js/main.js
@@ -8,7 +8,37 @@ document.addEventListener('DOMContentLoaded', function() {
     setUpPostEditing();
     verifyInputMatch();
     updatePasswordCheck();
+    adjustTimeZone();
 }, false);
+
+/**
+ * This function searches the page for timestamp elements and then updates the timezone in each
+ * element to be the user's local time.
+ */
+function adjustTimeZone() {
+    const timestamps = document.getElementsByClassName('timestamp');
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+    var length = timestamps.length;
+    var i = 0;
+    for(i; i < length; i++) {
+        /* the date and time value saved on the server (UTC) vs the user's local time zone */
+        var dateServer = new Date(timestamps[i].innerHTML + 'Z');
+        var dateUser = new Date(dateServer.toLocaleString('en-US', { timeZone: timeZone }));
+        
+        const formattedDate = dateUser.toLocaleDateString('en-US', {
+            weekday: 'long', 
+            month: 'long', 
+            day: 'numeric', 
+            year: 'numeric' 
+        });
+        const formattedTime = dateUser.toLocaleTimeString('en-US', { 
+            hour: '2-digit', 
+            minute: '2-digit' 
+        });
+        timestamps[i].innerHTML = formattedDate + ' at ' + formattedTime;
+    }
+}
 
 /**
  * This function makes a password verification field appear if the user is trying to update 
@@ -79,10 +109,6 @@ function setUpPostEditing() {
     }
     return;
 }
-
-/*
-Goal: Create timestamps for user-visible actions that are based on a user's time zone.
-*/
 
 /*
 Goal: combine all reCaptcha scripts into one function defined here.

--- a/src/templates/comment-section.html
+++ b/src/templates/comment-section.html
@@ -19,7 +19,7 @@
             {# comment header #}
             <div class="hbox padded v-centered">
                 <a href="/user/{{ c['uid'] }}">@{{ c['username'] }}</a>
-                <p>{{ c['timestamp'] }}</p>
+                <p class="timestamp">{{ c['timestamp'] }}</p>
                 {# If the logged in user is the author, a delete button will appear #}
                 {% if (data['logged_in_user'] is not none) and
                     (data['logged_in_user']['uid'] == c['uid']) -%}


### PR DESCRIPTION
Timestamps within the page (such as on posts and comments) will now be in a more human-readable format, and also reflect the user's local time zone. 

Later, I would like to add support for a user to choose their time zone manually, in which case I would update this function to use that value instead. For the time being, the time zone is the one implicitly received from the local date time functions.

closes #75 