### PR TITLE
Update account deletion to newer field macro

### DIFF
--- a/src/templates/form.html
+++ b/src/templates/form.html
@@ -207,7 +207,7 @@
 
 {% macro delete_account(limits) %}
 <form method="post" action="/leave">
-    {{ password_field(limits) }}
+    {{ field('password', limits) }}
     <input type="submit" value="request">
 </form>
 {% endmacro %}


### PR DESCRIPTION
This feature was broken from the previous wave of form refactoring, so I have updated it to the newer field macro design and it works again.